### PR TITLE
support gdalraster output as vector

### DIFF
--- a/R/ximage.R
+++ b/R/ximage.R
@@ -164,6 +164,16 @@ ximage.default <- function(x, extent = NULL, zlim = NULL, add = FALSE, ..., xlab
     ximage.list(x, extent = extent, zlim = zlim, add = add, ..., xlab = xlab, ylab = ylab, col = col)
     return(invisible(x))
   }
+  
+  if (is.numeric(x) && "gis" %in% names(attributes(x))) {
+    ## vector output from gdalraster
+    gis <- attr(x, "gis")
+    x_list <- asplit(array(x, dim = gis$dim), MARGIN=3)
+    attr(x_list, "gis") <- gis
+    ximage.list(x_list, extent = extent, zlim = zlim, add = add, ..., xlab = xlab, ylab = ylab, col = col)
+    return(invisible(x_list))
+  }
+  
   stopifnot(inherits(x, "array"))
 
    if (is.raw(x)) {


### PR DESCRIPTION
This pull request adds support in `ximage()` for the output of `gdalraster::read_ds()` which is a vector of pixel values by default. The  vector may be single-band or 3-band RGB, and has attribute `gis`, a list with dimension (`$dim`), bounding box (`$bbox`) and spatial reference (`$srs`).

`ximage()` already supports gdalraster output in list form (`read_ds()` with `as_list = TRUE`), so we can check for a numeric vector with `gis` attribute, convert to the list form, and pass to `ximage.list()`.